### PR TITLE
Fix unicode surrogate pair handling

### DIFF
--- a/js2xml/xmlvisitor.py
+++ b/js2xml/xmlvisitor.py
@@ -8,6 +8,8 @@ import lxml.etree as ET
 
 
 invalid_unicode_re = re.compile(u"""[\u0001-\u0008\u000b\u000e-\u001f\u007f]""", re.U)
+surrogate_unicode_re = re.compile(u'[\\ud800-\\udbff][\\udc00-\\udfff]', re.U)
+
 
 def unescape_string(input_string):
     input_string = invalid_unicode_re.sub(u"\ufffd", input_string)
@@ -251,6 +253,9 @@ class XmlVisitor(object):
 
     def visit_String(self, node):
         str_value = pyast.literal_eval("u"+node.value)
+        if surrogate_unicode_re.search(str_value):
+            in_utf16 = str_value.encode('utf16', 'surrogatepass')
+            str_value = in_utf16.decode('utf16')
         return [E.string(unescape_string(str_value))]
 
     def visit_Continue(self, node):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -148,6 +148,8 @@ bar";
         """,
         [u'\u13e9\u0352\u0362\u044f\u2778\xb3\u1d43\u034e\u034e\u0442\u035b\u13b7\u0362\u033b\u1d51A\u0362\u13de\ufffd\ufffd\u277c00b']
         ),
+        # surrogate pairs
+        (r'''var name = "\ud835\udebd"''', [u'\U0001d6bd']),
     ]
 
     for snippet, expected in jscode_snippets:


### PR DESCRIPTION
Python uses UTF-8 by default which doesn't like surrogate pairs. This PR attempts to replace surrogate pairs in the input strings by their pure-unicode counterparts.