### PR TITLE
Opening in U mode has been deprecated and removed in Python 3.10.

### DIFF
--- a/js2xml/__main__.py
+++ b/js2xml/__main__.py
@@ -13,10 +13,7 @@ def main():
     ap.add_argument('filenames', nargs='*', default=['-'])
     args = ap.parse_args()
 
-    if six.PY2:
-        mode = 'rU'
-    else:
-        mode = 'r'
+    mode = 'rU' if six.PY2 else 'r'
 
     for fn in args.filenames:
         fo = sys.stdin if fn == '-' else open(fn, mode)

--- a/js2xml/__main__.py
+++ b/js2xml/__main__.py
@@ -2,6 +2,8 @@
 import sys
 from argparse import ArgumentParser
 
+import six
+
 import js2xml
 
 
@@ -11,8 +13,13 @@ def main():
     ap.add_argument('filenames', nargs='*', default=['-'])
     args = ap.parse_args()
 
+    if six.PY2:
+        mode = 'rU'
+    else:
+        mode = 'r'
+
     for fn in args.filenames:
-        fo = sys.stdin if fn == '-' else open(fn, 'rU')
+        fo = sys.stdin if fn == '-' else open(fn, mode)
         parsed = js2xml.parse(fo.read())
         print(js2xml.pretty_print(parsed))
 


### PR DESCRIPTION
Fixes #37 