### PR TITLE
Cover js2xml 0.4.0 in the release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ You can install js2xml via [PyPI](https://pypi.python.org/pypi/js2xml):
 
 # Changelog
 
+## v0.4.0 (2020-05-??)
+
+- Add Python 3.7 and 3.8 support, drop Python 3.4 support
+
+- Use calmjs.parse instead of slimit for JavaScript parsing
+
+  [calmjs.parse](https://github.com/calmjs/calmjs.parse) is a well-maintained
+  fork of [slimit](https://github.com/rspivak/slimit) which solves some of its
+  shortcomings, such as support for JavaScript keywords being used as object
+  keys.
+
+  However, calmjs.parse also introduces slight changes to the output of js2xml,
+  making this change backward-incompatible.
+
+- Fix unicode surrogate pair handling
+
+- Code cleanup for Python 3
+
 ## v0.3.1 (2017-08-03)
 
 - Fix packaging

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can install js2xml via [PyPI](https://pypi.python.org/pypi/js2xml):
 
 # Changelog
 
-## v0.4.0 (2020-05-??)
+## v0.4.0 (2020-06-04)
 
 - Add Python 3.7 and 3.8 support, drop Python 3.4 support
 

--- a/README.md
+++ b/README.md
@@ -99,15 +99,15 @@ You can install js2xml via [PyPI](https://pypi.python.org/pypi/js2xml):
 
 - Add Python 3.7 and 3.8 support, drop Python 3.4 support
 
-- Use calmjs.parse instead of slimit for JavaScript parsing
+- Use `calmjs.parse` instead of `slimit` for JavaScript parsing
 
-  [calmjs.parse](https://github.com/calmjs/calmjs.parse) is a well-maintained
-  fork of [slimit](https://github.com/rspivak/slimit) which solves some of its
-  shortcomings, such as support for JavaScript keywords being used as object
-  keys.
+  [`calmjs.parse`](https://github.com/calmjs/calmjs.parse) is a well-maintained
+  fork of [`slimit`](https://github.com/rspivak/slimit) which solves some of
+  its shortcomings, such as support for JavaScript keywords being used as
+  object keys.
 
-  However, calmjs.parse also introduces slight changes to the output of js2xml,
-  making this change backward-incompatible.
+  However, `calmjs.parse` also introduces slight changes to the output of
+  js2xml, making this change backward-incompatible.
 
 - Fix unicode surrogate pair handling
 


### PR DESCRIPTION
Because our major version is still 0, I bumped the minor version instead, in line with [semantic versioning](https://semver.org/). [Caret requirements in poetry](https://python-poetry.org/docs/dependency-specification/#caret-requirements), for example, take that into account, and treat minor versions while major is 0 similarly to how they treat major versions once major is 1+.