### PR TITLE
Update print example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can install js2xml via [PyPI](https://pypi.python.org/pypi/js2xml):
 >>> parsed.xpath("//funcdecl/@name")  # extracts function name
 ['factorial']
 >>>
->>> print js2xml.pretty_print(parsed)  # pretty-print generated XML
+>>> print(js2xml.pretty_print(parsed))  # pretty-print generated XML
 <program>
   <funcdecl name="factorial">
     <parameters>
@@ -88,8 +88,6 @@ You can install js2xml via [PyPI](https://pypi.python.org/pypi/js2xml):
 </program>
 
 >>>
-
-
 ```
 
 


### PR DESCRIPTION
`from __future__ import print_function` is not really necessary, and it would add unnecessary complexity to the example IMHO. This does not get interpreted as a function call in Py2, but as a statement with parenthesized arguments, which doesn't change its semantics.